### PR TITLE
Custom Templates

### DIFF
--- a/plugins/monaco-wikitext/plugin.info
+++ b/plugins/monaco-wikitext/plugin.info
@@ -8,5 +8,5 @@
     "source": "https://github.com/smilyorg/tw5-monaco",
     "plugin-type": "plugin",
     "parent-plugin": "$:/plugins/smilyorg/monaco",
-	"list": "readme license"
+	"list": "readme license stampprefix"
 }

--- a/plugins/monaco-wikitext/stampprefix.tid
+++ b/plugins/monaco-wikitext/stampprefix.tid
@@ -1,0 +1,3 @@
+title: $:/config/smilyorg/monaco-wikitext/stampPrefix
+
+;


### PR DESCRIPTION
I used https://twelvety.micro.blog/2019/01/12/autocomplete-of-tiddlywiki.html before Monaco and I was missing the possibility to have templates.

As I couldn't figure out if and how snippets work, I used the completion mechanism.

You can have a custom marker for the templates completion. Default is `;` so in the double form it is `;;`. It can be changed in `$:/config/smilyorg/monaco-wikitext/stampPrefix`.

It will consider all the toddler, tagged with `$:/stamp` and strip all prefixes up to the last `/` from the Tiddler name. Leaving only the last part.

If you select the Completion, the `;;` and the name is removed and the text of the toddler is inserted instead.

This probably helps someone besides me, too.